### PR TITLE
Issue 35 bugfix

### DIFF
--- a/src/currencycloud/errors/api.py
+++ b/src/currencycloud/errors/api.py
@@ -64,10 +64,7 @@ class ApiError(Exception):
             'response': {
                 'status_code': self.status_code,
                 'date': self.raw_response.headers['Date'],
-                'request_id': int(
-                    self.raw_response.headers.get(
-                        'x-request-id',
-                        0)),
+                'request_id': self.raw_response.headers.get('x-request-id')
             },
             'errors': [
                 m.to_h() for m in self.messages],


### PR DESCRIPTION
bugfix: 
**_x-request-id_** in the header is now a str and cannot be cast to int. 
e.g. c26abaea-d55e-494c-a1c7-59b440301bb5

1. removed cast to int since within __str__ since it buys us very little
2. default to 0 is also misleading, leave it as a null so it's obvious the x-request-id is missing