### PR TITLE
Remove development dependencies from setup.py and update URL to point at this repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,8 @@ setup(
 
     keywords=[],
     install_requires=['requests', 'PyYAML', 'deprecation'],
+    tests_require=[
+        'pytest', 'mock', 'requests-mock', 'betamax', 'betamax-serializers'
+    ],
     test_suite='tests'
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
 
     author='Francesco Boffa',
     author_email='francesco.boffa@currencycloud.com',
-    url='https://connect.currencycloud.com/documentation/getting-started/introduction',
+    url='https://github.com/CurrencyCloud/currencycloud-python',
 
     packages=find_packages('src'),
     package_dir={'': 'src'},
@@ -43,6 +43,6 @@ setup(
     ],
 
     keywords=[],
-    install_requires=['requests', 'PyYAML', 'deprecation', 'pytest', 'mock', 'requests-mock', 'betamax', 'betamax-serializers'],
+    install_requires=['requests', 'PyYAML', 'deprecation'],
     test_suite='tests'
 )


### PR DESCRIPTION
## Motivation
With regards to changing the URL: That URL is broken, and when I click on the "homepage" link on PyPI, I (and I imagine most other developers as well) want to land on the source code, not on the API docs.

With regards to removing dev dependencies: They shouldn't be installed as transitive dependencies at runtime.